### PR TITLE
Use multiple flag to control DropZone internal state

### DIFF
--- a/src/DropZone.tsx
+++ b/src/DropZone.tsx
@@ -99,7 +99,7 @@ export const DropZone = ({
   }
 
   function setFile(file: FileData) {
-    setFiles((filesObj) => ({ ...filesObj, [file.id]: file }))
+    setFiles((filesObj) => multiple ? ({ ...filesObj, [file.id]: file }) : ({ [file.id]: file }))
   }
 
   function removeFile(id: string) {

--- a/src/DropZone.tsx
+++ b/src/DropZone.tsx
@@ -144,6 +144,5 @@ DropZone.propTypes = {
   dragActiveText: PropTypes.string,
   unsupportedText: PropTypes.string,
   showRemoveIcon: PropTypes.bool,
-  maxFiles: PropTypes.number,
   multiple: PropTypes.bool,
 }


### PR DESCRIPTION
I thought that changing the `multiple` flag of `react-dropzone` would be enough, but the internal state of `uploods` is keeping the state with multiple files (even when multiple is false). So, this PR fixes this.