### PR TITLE
Always hash file name

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,9 +41,7 @@ export const processFile = async (
   const preparedFile = await prepareImage(file, config)
   const fileData = await getFileData(preparedFile)
   const timeStamp = new Date().getTime().toString()
-  const finalName = config.overwrite
-    ? fileData.name
-    : `${timeStamp}-${fileData.name}`
+  const finalName = `${timeStamp}-${fileData.name}`
   const id = compact(['uploods', config.prefix, finalName]).join('/')
 
   return {


### PR DESCRIPTION
We have a bug where the `overwrite` option must be used. Otherwise, the dropzone will include the full file binary in the input value and bloat the application.
That means we can't prevent files with the same names to be overwritten, which is the real use cases we have now.

This PR forces the file names to be unique regardless of that option. We can investigate further but publishing this will solve the immediate problem.